### PR TITLE
fix: build error from missing component exports

### DIFF
--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,8 +1,2 @@
-export { Input } from './Input';
-export type { InputProps } from './Input';
-
-export { Button } from './Button';
-export type { ButtonProps } from './Button';
-
 export { default as Logo } from './Logo';
 export type { LogoProps } from './Logo';


### PR DESCRIPTION
## Summary
• Fixed build error caused by missing component exports in atoms index file
• Removed exports for deleted Input and Button components
• Build now compiles successfully

## Problem
After merging the component cleanup, the build was failing with:
```
Module not found: Can't resolve './Input'
Module not found: Can't resolve './Button'
```

## Root Cause
The `src/components/atoms/index.ts` file was still trying to export `Input` and `Button` components that were deleted in the previous cleanup, but the export removal didn't make it to main properly.

## Solution
- Removed `Input` and `InputProps` exports from atoms index
- Removed `Button` and `ButtonProps` exports from atoms index  
- Kept only `Logo` and `LogoProps` exports (the only remaining component)

## Testing
✅ Build now compiles successfully with `bun run build`
✅ No module resolution errors
✅ Chat prototype functionality preserved

## Files Changed
- `src/components/atoms/index.ts` - Updated exports to match available components

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined component library exports to reduce the public surface. No changes to UI or functionality.
* **Chores**
  * Cleaned up related internal typings. No end-user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->